### PR TITLE
Hide popover and auto focus to textbox

### DIFF
--- a/app/scripts.babel/contents.js
+++ b/app/scripts.babel/contents.js
@@ -21,5 +21,7 @@ window.onload = function(){
     });
 
     chatwork_textbox.value = mentions + '\n' + chatwork_textbox.value;
+    chatwork_textbox.click();
+    chatwork_textbox.focus();
   })
 }


### PR DESCRIPTION
「Simpleにすべて選択」をクリックするとpopoverを表示されないようにするとテキストボクスをfocusする。